### PR TITLE
Troubleshooting message about Wordpress database errors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ If your self-signed certs have expired (`ERR_CERT_DATE_INVALID`), simply delete
 the `certs/self-signed` directory, run `./certs/create-certs.sh`, and restart
 the stack.
 
+The `install-wp` script may warn you that it was unable to create the uploads directory. See [issue #3](https://github.com/chriszarate/docker-wordpress-vip-go/issues/3) for instructions on how to deal with this.
 
 [vip-go]: https://vip.wordpress.com/documentation/vip-go/
 [photon]: https://jetpack.com/support/photon/

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ the stack.
 
 The `install-wp` script may warn you that it was unable to create the uploads directory. See [issue #3](https://github.com/chriszarate/docker-wordpress-vip-go/issues/3) for instructions on how to deal with this.
 
+If the `install-wp` script generates Wordpress database errors when you run it, comment out the wordpress VIP plugins on line 23 of `docker-compose.yml` before starting docker and running `install-wp`. Once wordpress is installed successfully you can uncomment the line. The errors seem to occur because of a [fault in the wordpress VIP plugins](https://github.com/Automattic/vip-support/issues/87).
+
 [vip-go]: https://vip.wordpress.com/documentation/vip-go/
 [photon]: https://jetpack.com/support/photon/
 [image]: https://hub.docker.com/r/chriszarate/wordpress/


### PR DESCRIPTION
When I ran `install-wp` I got 41 Wordpress database errors. It seems that `vip-support/class-vip-support-role.php` tries to [create database entries before the database table it needs exists](https://github.com/Automattic/vip-support/issues/87). I've reported the bug to Automattic but I thought it might be useful to add something to this project's troubleshooting section.