### PR TITLE
Fix for ERR_CERT_COMMON_NAME_INVALID errors.

### DIFF
--- a/certs/create-certs.sh
+++ b/certs/create-certs.sh
@@ -45,7 +45,7 @@ if [ ! -f "$CERT_DIR/$DOMAIN.crt" ] || [ ! -f "$CERT_DIR/$DOMAIN.key" ]; then
     -e "SSL_CSR=/certs/out/$DOMAIN.csr" \
     -e "SSL_KEY=/certs/out/$DOMAIN.key" \
     -e "SSL_SUBJECT=$DOMAIN" \
-    paulczar/omgwtfssl:latest \
+    superseb/omgwtfssl:latest \
     > /dev/null
 else
   echo "Found key and self-signed certificate for $DOMAIN, skipping...."


### PR DESCRIPTION
Certificates without a Subject Alternative Name now generate an ERR_CERT_COMMON_NAME_INVALID error in Chrome. A [pull request](https://github.com/paulczar/omgwtfssl/pull/16) has been opened against paulczar/omgwtfssl but not yet accepted. The superseb/omgwtfssl fork contains the fix.